### PR TITLE
[feat] FPS subclass with self-defining metadata

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,6 +15,8 @@ The functions below test for editable/non-editable install
 and whether the tests are run from pyMilk dir or externally. This matters due to PYTHONPATH resolution.
 '''
 
+#def clean_all_possible_stale_things():
+
 
 def hack_cacaoprocesstools_from_abspath():
     '''
@@ -23,14 +25,18 @@ def hack_cacaoprocesstools_from_abspath():
     repo's build system. It's fully external.
     '''
     os.makedirs('/tmp/nox/', exist_ok=True)
-    try:
-        os.symlink(
-                '/home/vdeo/mambaforge/lib/python3.10/site-packages/CacaoProcessTools.cpython-310-x86_64-linux-gnu.so',
-                '/tmp/nox/CacaoProcessTools.cpython-310-x86_64-linux-gnu.so')
-    except FileExistsError:
-        ...
+    for py_ver in range(7, 15):
+        try:
+            os.remove(
+                    f'/tmp/nox/CacaoProcessTools.cpython-3{py_ver}-x86_64-linux-gnu.so'
+            )
+            os.symlink(
+                    f'{os.environ["MILK_INSTALLDIR"]}/python/CacaoProcessTools.cpython-3{py_ver}-x86_64-linux-gnu.so',
+                    f'/tmp/nox/CacaoProcessTools.cpython-3{py_ver}-x86_64-linux-gnu.so'
+            )
+        except FileExistsError:
+            ...
 
-    sys.path.append('/tmp/nox/')
     import CacaoProcessTools
 
 
@@ -41,6 +47,7 @@ def tests_not_installed_inner(session: nox.Session):
     INNER testing, ie we run pytest while PWD is $PYMILK_ROOT (often $HOME/src/pyMilk/)
     ACTUALLY THAT CANNOT WORK, due to uncompiled ImageStreamIO / CacaoProcessTools which gets compiled on install.
     '''
+    import CacaoProcessTools
     ...
 
 
@@ -50,17 +57,17 @@ def tests_editable_inner(session: nox.Session):
     EDITABLE installation, ie `pip install -e .`; test from inside the project root.
     INNER testing, ie we run pytest while PWD is $PYMILK_ROOT (often $HOME/src/pyMilk/)
     '''
-    session.run("./clean.sh", external=True)
+    #session.run("./clean.sh", external=True)
+
+    hack_cacaoprocesstools_from_abspath()
 
     session.install("pytest", "pyright")
     session.install("-e", ".")
     session.install("pyright")
 
     # Run tests from inside the project root
-    session.run("pytest")
-
-    # What about the CacaoProcessTools dependency????
-    # We basically need all of milk for that to work...
+    # Pass the env for CacaoProcessTools
+    session.run("pytest", env={'PYTHONPATH': '/tmp/nox'})
 
 
 @nox.session
@@ -69,18 +76,19 @@ def tests_editable_outer(session: nox.Session):
     EDITABLE installation, ie `pip install -e .`; test from outside the project root.
     OUTER testing, ie we run pytest while PWD is NOT $PYMILK_ROOT; here's its /tmp/nox
     '''
-    session.run("./clean.sh", external=True)
+    #session.run("./clean.sh", external=True)
+
+    hack_cacaoprocesstools_from_abspath()
 
     session.install("pytest", "pyright")
     session.install("-e", ".")
     session.install("pyright")
 
-    hack_cacaoprocesstools_from_abspath()
-
     # Run tests from outside the project root
     project_dir = os.path.abspath(os.getcwd())
-    with session.chdir("/tmp/nox"):  #TODO maybe
-        session.run("pytest", "--pdb", project_dir)
+    os.makedirs("/tmp/nox_runtime", exist_ok=True)
+    with session.chdir("/tmp/nox_runtime"):
+        session.run("pytest", project_dir, env={'PYTHONPATH': '/tmp/nox'})
 
 
 @nox.session
@@ -89,7 +97,7 @@ def tests_non_editable_inner_and_outer(session: nox.Session):
     NON-EDITABLE installation, ie `pip install .`; run from both inside and outside the project root.
     IN and OUT testing
     '''
-    session.run("./clean.sh", external=True)
+    #session.run("./clean.sh", external=True)
 
     session.install("pytest")
     session.install(".")
@@ -99,5 +107,6 @@ def tests_non_editable_inner_and_outer(session: nox.Session):
     # Change cwd to something else...
     # Otherwise name collision with the source folder, rather than the install in the venv.
     project_dir = os.path.abspath(os.getcwd())
-    with session.chdir("/tmp/nox"):
-        session.run("pytest", project_dir)
+    os.makedirs("/tmp/nox_runtime", exist_ok=True)
+    with session.chdir("/tmp/nox_runtime"):
+        session.run("pytest", project_dir, env={'PYTHONPATH': '/tmp/nox'})

--- a/noxfile.py
+++ b/noxfile.py
@@ -48,7 +48,6 @@ def tests_not_installed_inner(session: nox.Session):
     INNER testing, ie we run pytest while PWD is $PYMILK_ROOT (often $HOME/src/pyMilk/)
     ACTUALLY THAT CANNOT WORK, due to uncompiled ImageStreamIO / CacaoProcessTools which gets compiled on install.
     '''
-    import CacaoProcessTools
     ...
 
 

--- a/pyMilk/interfacing/fps.py
+++ b/pyMilk/interfacing/fps.py
@@ -35,15 +35,23 @@ if typ.TYPE_CHECKING:
     FPVal: typ.TypeAlias = str | bool | int | float
 
 
-class FPSErrnoError(Exception):
+class FPSBaseError(Exception):
     pass
 
 
-class FPSDoesntExistError(Exception):
+class FPSErrnoError(FPSBaseError):
     pass
 
 
-class SmartFPSInitError(Exception):
+class FPSOverrideError(FPSBaseError):
+    pass
+
+
+class FPSDoesntExistError(FPSBaseError):
+    pass
+
+
+class SmartFPSInitError(FPSBaseError):
     pass
 
 
@@ -55,29 +63,27 @@ class FPS:
     @classmethod
     def create(cls: type[_T_Subclass], name: str,
                force_recreate: bool = False) -> _T_Subclass:
+        '''
+        Create an empty FPS.
+        The only attribute set is the name.
+        '''
         fps_filepath = os.environ['MILK_SHM_DIR'] + f'/{name}.fps.shm'
-        if force_recreate and os.path.exists(fps_filepath):
-            os.remove(fps_filepath)
+        if os.path.exists(fps_filepath):
+            if force_recreate:
+                os.remove(fps_filepath)
+            else:
+                raise FPSOverrideError(
+                        f"FPS {name} exist and {force_recreate=}.")
 
-        # FIXME we need an API bind. OR AT LEAST USE THE milk-session wrapper
-        SHM_DIR = os.environ["MILK_SHM_DIR"]
-        os.system(
-                f'MILK_SHM_DIR={SHM_DIR} milk-exec "fpscreate 1000 {name} Comment"'
-        )
+        _fps = CPTFPS(name,
+                      True)  # thrown away, opened as "read" in constructor
+
         fps = cls(name)
         fps.add_param('Name', 'Name', FPS_type.STRING,
                       FPS_flags.DEFAULT_STATUS)  # 0x5 = VISIBLE | ACTIVE
         fps['Name'] = name
 
-        fps.post_create_set_defaults()
-
         return fps
-
-    def post_create_set_defaults(self) -> None:
-        '''
-        Handle for subclassing
-        '''
-        return None
 
     def __init__(self, name: str) -> None:
         self.name = name
@@ -99,6 +105,7 @@ class FPS:
 
     def add_param(self, key: str, comment: str, datatype: int,
                   flags: int = FPS_flags.DEFAULT_INPUT) -> None:
+        # TODO: _autorelink implementation !
         self.fps.add_entry(key, comment, datatype, flags)
         self.key_types[key] = datatype
 
@@ -107,12 +114,14 @@ class FPS:
         self.fps.un
 
     def set_param(self, key: str, value: FPVal) -> None:
+        # TODO: _autorelink implementation !
         if key in self.key_types:
             self.fps[key] = value
         else:
             raise ValueError(f'set_param: key {key} not in FPS {self.name}.')
 
     def get_param(self, key: str) -> FPVal:
+        # TODO: _autorelink implementation !
         if key in self.key_types:
             return self.fps[key]
         else:
@@ -280,6 +289,9 @@ class SmartAttributesFPS(FPS):
     gain: ('Averaging gain', FPS_type.FLOAT64, FPS_flags.DEFAULT_INPUT)
 
     Am I reinventing named tuples / named dicts?
+
+    # TODO: make a subclass wherein _DICT_METADATA just maps all typical types to FPS types.
+    # TODO: and just puts FPS_flags to RW at runtime at all time.
     '''
 
     _DICT_METADATA: dict[str, tuple[str, FPS_type, FPS_flags]]
@@ -297,6 +309,7 @@ class SmartAttributesFPS(FPS):
         but we'd have to delete the FPS created by __new__ in case of non-compliance and aborting
         the __init__... so better in __new__
         '''
+        cls._cls_assert_find_annotations_not_overridden()
         cls._cls_metadata_checks()
         return super(SmartAttributesFPS, cls).__new__(cls)
 
@@ -333,19 +346,45 @@ class SmartAttributesFPS(FPS):
                 )
 
     @classmethod
-    def _cls_find_annotations(cls: type[_T_Subclass]
-                              ) -> typ.Iterable[str]:  # Really a dict_keys
-        annotations = cls.__annotations__.copy()
-        next_in_mro = cls.__mro__[
-                1]  # This will break multiple inheritance if any
-        if hasattr(next_in_mro, '_cls_find_annotations'):
-            annotations.update(
-                    next_in_mro._cls_find_annotations())  # type: ignore
+    def _cls_assert_find_annotations_not_overridden(cls) -> None:
+        for cls_in_hierarchy in cls.__mro__:
+            if cls_in_hierarchy is SmartAttributesFPS:
+                break
+            if '_cls_find_annotations' in cls_in_hierarchy.__dict__:
+                raise SmartFPSInitError(
+                        f'{cls_in_hierarchy.__name__} overrides '
+                        '_cls_find_annotations, which is forbidden. '
+                        'Use _cls_annotation_technical_keys_to_remove instead.'
+                )
 
-        if '_DICT_METADATA' in annotations:
-            del annotations['_DICT_METADATA']
+    @classmethod
+    def _cls_find_annotations(cls: type[_T_Subclass]
+                              ) -> dict[str, typ.Any]:  # Really a dict_keys
+
+        # Since this explores the MRO, it must NOT be subclassed !!!
+        annotations = {}
+        all_to_remove = set()
+        for cls_in_hierarchy in cls.__mro__[::-1]:
+            if not hasattr(cls_in_hierarchy, '__annotations__'):
+                continue
+
+            annotations.update(cls_in_hierarchy.__annotations__.copy())
+            if not hasattr(cls_in_hierarchy,
+                           '_cls_annotation_technical_keys_to_remove'):
+                continue
+
+            all_to_remove.update(cls_in_hierarchy.
+                                 _cls_annotation_technical_keys_to_remove())
+
+        for key in all_to_remove:
+            del annotations[key]
 
         return annotations
+
+    @classmethod
+    def _cls_annotation_technical_keys_to_remove(cls: type[_T_Subclass]
+                                                 ) -> list[str]:
+        return ['_DICT_METADATA']
 
     def _prop_fget(self, prop_name: str):
 
@@ -381,3 +420,53 @@ class SmartAttributesFPS(FPS):
             #setattr(self, '___' + key, getattr(self, key))
             setattr(self.__class__, key,
                     property(self._prop_fget(key), self._prop_fset(key)))
+
+
+class SmartAttributesFPSAutoMetadata(SmartAttributesFPS):
+    '''
+    Subclass of SmartAttributeFPS intended for mostly python use.
+
+    Question: what happens if the underlying FPS exists and the flags don't match ???
+    '''
+    _cls_metadata_is_init: typ.ClassVar[bool] = False
+    _ANNOTATION_TYPE_MAPPER: typ.ClassVar = {
+            bool: FPS_type.ONOFF,
+            int: FPS_type.INT64,
+            float: FPS_type.FLOAT64,
+            str: FPS_type.STRING,
+    }
+
+    _T_Subclass = typ.TypeVar('_T_Subclass',
+                              bound='SmartAttributesFPSAutoMetadata'
+                              )  # Any subclass of this class
+
+    def __new__(cls: type[_T_Subclass], name: str) -> _T_Subclass:
+        if not cls._cls_metadata_is_init:
+            cls._cls_metadata_fill_dict()
+            cls._cls_metadata_is_init = True
+        return super(SmartAttributesFPSAutoMetadata, cls).__new__(cls, name)
+
+    @classmethod
+    def _cls_metadata_fill_dict(cls) -> None:
+        if cls._cls_metadata_is_init:
+            raise SmartFPSInitError('Already initialized, should not be here.')
+        annotations = cls._cls_find_annotations()
+
+        cls._DICT_METADATA = {}
+
+        for attr_name, annotation_type in annotations.items():
+            if not annotation_type in cls._ANNOTATION_TYPE_MAPPER:
+                raise SmartFPSInitError(
+                        'Cannot SmartAttributesFPSAutoMetadata with '
+                        f'attribute {attr_name} annotation type {annotation_type}.'
+                )
+
+            cls._DICT_METADATA[attr_name] = (
+                    f'{attr_name}:{annotation_type}',
+                    cls._ANNOTATION_TYPE_MAPPER[annotation_type],
+                    FPS_flags.DEFAULT_INPUT)
+
+    @classmethod
+    def _cls_annotation_technical_keys_to_remove(cls: type[_T_Subclass]
+                                                 ) -> list[str]:
+        return ['_ANNOTATION_TYPE_MAPPER', '_cls_metadata_is_init']

--- a/tests/interfacing/fps_test.py
+++ b/tests/interfacing/fps_test.py
@@ -65,6 +65,24 @@ def test_smart_fps_instantiation():
     assert g.gain == pytest.approx(3.1415)
 
 
+def test_smart_fps_find_annotations_cannot_be_overridden():
+
+    class H(fps.SmartAttributesFPS):
+        gain: float
+        _DICT_METADATA = {
+                'gain': ('gain', fps.FPS_type.FLOAT32,
+                         fps.FPS_flags.DEFAULT_INPUT)
+        }
+
+        @classmethod
+        def _cls_find_annotations(cls):
+            return {'gain': float}
+
+    with pytest.raises(fps.SmartFPSInitError,
+                       match='overrides _cls_find_annotations'):
+        H.create('some_name')
+
+
 @pytest.fixture
 def fixt_dumb_fps():
     with pytest.raises(fps.FPSDoesntExistError):
@@ -236,3 +254,26 @@ def test_fps_filesystem_operations():
     # Verify FPS was properly destroyed
     with pytest.raises(fps.FPSDoesntExistError):
         fps.FPS(fps_name)
+
+
+def test_smart_fps_auto():
+
+    class NewFPS(fps.SmartAttributesFPSAutoMetadata):
+        gain: float
+        counter: int
+        name_of_something: str
+
+    f = NewFPS.create('a_name')
+
+    f2 = NewFPS('a_name')
+    f2.gain = 3.1415
+    f2.counter = 100
+    f2.name_of_something = 'YOLO'
+
+    assert f.gain == 3.1415
+    assert f.counter == 100
+    assert f.name_of_something == 'YOLO'
+
+    # TODO breakpoint() here and figure out the interaction with milk-fpsCTRL.
+
+    f.destroy()


### PR DESCRIPTION
An FPS subclass defined for IPC between python process without requiring interaction with MILK.

All the parameters annotated self-define the METADATA dict that is passed to the C code; all parameters simply become FPS_DEFAULT / FPS_INPUT.