### PR TITLE
Better GPU support with cupy

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ A CLI helper is also available to create streams from the shell:
 creashmim mystream 256 256 --type=f32 --kw=50
 ```
 
+### GPU Capability
+
+
+
 ### FPS — Function Parameter Structures
 
 The `FPS` class interfaces with CACAO parameter structures used to configure and control real-time processes.

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,8 +1,58 @@
 import os, sys
 import nox
 import shutil
+import subprocess
+from pathlib import Path
 
 nox.options.error_on_missing_interpreters = False
+
+
+def _imagestreamio_has_cuda(session: nox.Session) -> bool:
+    result = subprocess.run(
+            [
+                    f"{session.bin}/python", "-c",
+                    "from pyMilk.interfacing.shm import IMAGESTREAMIO_HAVE_CUDA; raise SystemExit(not IMAGESTREAMIO_HAVE_CUDA)"
+            ],
+            capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def _cupy_package() -> str:
+    """Return the cupy wheel and the minimal NVRTC headers package for the installed CUDA version.
+
+    `cupy-cuda{N}x` is the fast pre-built wheel, but NVRTC needs compiler
+    headers at runtime to JIT-compile kernels.  Instead of pulling the full
+    toolkit via `cupy-cuda{N}x[ctk]`, we install only `nvidia-cuda-nvcc-cu{N}`
+    which is the single pip package that provides those headers — much smaller.
+
+    Falls back to plain 'cupy' if the CUDA version cannot be determined.
+    """
+    result = subprocess.run(["nvcc", "--version"], capture_output=True,
+                            text=True)
+    if result.returncode == 0:
+        for line in result.stdout.splitlines():
+            # e.g. "Cuda compilation tools, release 12.2, V12.2.140"
+            if "release" in line:
+                major = line.split("release")[1].strip().split(".")[0]
+                return f"cupy-cuda{major}x"
+    return "cupy"
+
+
+def _cuda_root() -> str | None:
+    result = subprocess.run(["which", "nvcc"], capture_output=True, text=True)
+    if result.returncode == 0:
+        # nvcc lives at $CUDA_ROOT/bin/nvcc
+        return str(Path(result.stdout.strip()).parent.parent)
+    return None
+
+
+def _set_cuda_env(session: nox.Session) -> None:
+    cuda_root = _cuda_root()
+    if cuda_root and not session.env.get("CUDA_PATH"):
+        session.env["CUDA_PATH"] = cuda_root
+
+
 '''
 I am investigating nox as an option to run the (some) tests with multiple "installation modes"
 In particular, with the dependency on libImageStreamIO.so and the building of the python
@@ -42,6 +92,10 @@ def tests_editable_inner_outer(session: nox.Session):
     session.install("-e", ".")
     #session.install("pyright") # why pyright twice ????
 
+    if _imagestreamio_has_cuda(session):
+        session.install(_cupy_package())
+        _set_cuda_env(session)
+
     # Run tests from inside the project root
     session.run("pytest")
 
@@ -71,6 +125,10 @@ def tests_non_editable_inner_and_outer(session: nox.Session):
     session.install("pytest")
     session.install(".")
 
+    if _imagestreamio_has_cuda(session):
+        session.install(_cupy_package())
+        _set_cuda_env(session)
+
     # Change cwd to something else...
     # Otherwise name collision with the source folder, rather than the install in the venv.
     project_dir = os.path.abspath(os.getcwd())
@@ -91,6 +149,10 @@ def tests_run_coverage(session: nox.Session):
     session.env['COVERAGE'] = 'ON'
     session.install('nanobind', 'setuptools', 'coverage', 'pytest')
     session.install('.')  # for dependencies only...
+
+    if _imagestreamio_has_cuda(session):
+        session.install(_cupy_package())
+        _set_cuda_env(session)
 
     session.run(*('python setup.py build_ext --inplace'.split()))
     print(os.path.abspath(os.getcwd()))

--- a/pyMilk/interfacing/shm.py
+++ b/pyMilk/interfacing/shm.py
@@ -35,7 +35,10 @@ Credit for ImageStreamIOWrap pybind interface: A. Sevin
 from __future__ import annotations
 
 import typing as typ
+import numpy as np
+
 if typ.TYPE_CHECKING:
+    IMAGESTREAMIO_HAVE_CUDA: int
     KWType = str | int | float
     KWDict = dict[str, KWType]
     KWCommentDict = dict[str, tuple[KWType, str]]
@@ -47,12 +50,16 @@ if typ.TYPE_CHECKING:
     from types import TracebackType
     ExcTpl = typ.TypeVar('ExcTpl', bound=BaseException)
 
+    import numpy.typing as npt
+    import cupy as cp
+
+    xp_ndarray = typ.TypeVar('xp_ndarray', np.ndarray, cp.ndarray)
+
 from . import glib_loader_fix
-from pyMilk.ImageStreamIOWrap import Image, Image_kw, Image_md
+from pyMilk.ImageStreamIOWrap import Image, Image_kw, Image_md, IMAGESTREAMIO_HAVE_CUDA
+# FIXME all np calls... in case the data is a cp array ! Review img_shapes as well.
 
 import datetime
-import numpy as np
-import numpy.typing as npt
 
 import time
 
@@ -82,7 +89,7 @@ class SHM:
     def __init__(
             self,
             fname: str,
-            data: None | np.ndarray |
+            data: None | xp_ndarray |
             tuple[tuple[int, ...], npt.DTypeLike] = None,
             nbkw: int = 50,
             shared: bool | typ.Literal[0, 1] = True,
@@ -173,7 +180,7 @@ class SHM:
         self.shared = True  # can't be other with OpenIm...
         self.location = self.IMAGE.md.location
 
-    def _finalize_init_creationmode(self, data: np.ndarray |
+    def _finalize_init_creationmode(self, data: xp_ndarray |
                                     tuple[tuple[int, ...], npt.DTypeLike],
                                     location: int, shared: bool |
                                     typ.Literal[0, 1], nbkw: int):
@@ -545,7 +552,7 @@ class SHM:
                  copy: bool = True, checkSemAndFlush: bool = True,
                  autorelink_if_need: bool = True,
                  return_none_on_timeout: typ.Literal[False] = False
-                 ) -> np.ndarray:
+                 ) -> xp_ndarray:
         ...
 
     @typ.overload
@@ -553,13 +560,13 @@ class SHM:
                  copy: bool = True, checkSemAndFlush: bool = True,
                  autorelink_if_need: bool = True,
                  return_none_on_timeout: typ.Literal[True] = True
-                 ) -> np.ndarray | None:
+                 ) -> xp_ndarray | None:
         ...
 
     def get_data(self, check: bool = False, timeout: float | None = 5.0,
                  copy: bool = True, checkSemAndFlush: bool = True,
                  autorelink_if_need: bool = True,
-                 return_none_on_timeout: bool = False) -> np.ndarray | None:
+                 return_none_on_timeout: bool = False) -> xp_ndarray | None:
         """
         Reads and returns the data part of the SHM file
         Parameters:
@@ -591,37 +598,23 @@ class SHM:
                     if return_none_on_timeout:
                         return None
 
-        if self.location >= 0:
-            if copy:
-                arr_sliced = self.IMAGE.copy()[self.readSlice]
-                if self.nDim == 2:
-                    return img_shapes.image_decode(arr_sliced, self.symcode)
-                elif self.nDim == 3:
-                    return img_shapes.full_cube_decode(
-                            arr_sliced,
-                            self.symcode,
-                            self.triDimState,
-                    )
-                else:
-                    return self.IMAGE.copy()[self.readSlice]
-            else:
-                raise AssertionError("copy=False not allowed on GPU.")
+        # FIXME ! image_decode, full_cube_decode don't have the same meaning
+        # in case of autoSqueeze collapsing dimensions.
+        # Should they apply before or after reducing dimensions??
+        arr_sliced = (self.IMAGE.copy()
+                      if copy else self.IMAGE.view())[self.readSlice]
+        if self.nDim == 2:
+            return img_shapes.image_decode(arr_sliced, self.symcode)
+        elif self.nDim == 3:
+            return img_shapes.full_cube_decode(
+                    arr_sliced,
+                    self.symcode,
+                    self.triDimState,
+            )
         else:
-            # This syntax is only allowed on CPU - segfaults if loc > 0
-            arr_sliced = (self.IMAGE.copy()
-                          if copy else self.IMAGE.view())[self.readSlice]
-            if self.nDim == 2:
-                return img_shapes.image_decode(arr_sliced, self.symcode)
-            elif self.nDim == 3:
-                return img_shapes.full_cube_decode(
-                        arr_sliced,
-                        self.symcode,
-                        self.triDimState,
-                )
-            else:
-                return arr_sliced
+            return arr_sliced
 
-    def set_data(self, data: np.ndarray, check_dt: bool = False,
+    def set_data(self, data: xp_ndarray, check_dt: bool = False,
                  autorelink_if_need: bool = False) -> None:
         """
         Upload new data to the SHM file.

--- a/pyMilk/util/img_shapes.py
+++ b/pyMilk/util/img_shapes.py
@@ -40,13 +40,24 @@ Second axis is column and left-to-right, hence "+x"
 This is good for not ovethinking indexing in your code.
 """
 from __future__ import annotations
+import typing as typ
+if typ.TYPE_CHECKING:
+    import cupy as cp
+
+    import numpy.typing as npt
+    import cupy.typing as cpt
+
+    cpNDArray: typ.TypeAlias = cpt.NDArray  # type: ignore # that hint is missing in cupy 14.0.1
+    xp_ndarray = typ.TypeVar('xp_ndarray', npt.NDArray, cpNDArray)
 
 import numpy as np
-import numpy.typing as npt
-import typing as typ
+try:
+    from cupy import get_array_module
+except:
+    get_array_module = lambda x: np
 
 
-def image_encode(im: npt.NDArray, s: int) -> npt.NDArray:
+def image_encode(im: xp_ndarray, s: int) -> xp_ndarray:
     # Cases 4 to 7: x and y must be swapped
     if s < 0 or s > 7:
         raise ValueError("symcode s must be 0-7")
@@ -54,22 +65,22 @@ def image_encode(im: npt.NDArray, s: int) -> npt.NDArray:
     if s == 0:
         return im
     elif s == 1:
-        return im[::-1, :]
+        return im[::-1, :]  # type: ignore
     elif s == 2:
-        return im[:, ::-1]
+        return im[:, ::-1]  # type: ignore
     elif s == 3:
-        return im[::-1, ::-1]
+        return im[::-1, ::-1]  # type: ignore
     else:
         return image_encode(im.T, s - 4)
 
 
-def image_decode(x: npt.NDArray, s: int) -> npt.NDArray:
+def image_decode(x: xp_ndarray, s: int) -> xp_ndarray:
     if s < 0 or s > 7:
         raise ValueError("symcode s must be 0-7")
     return image_encode(x, [0, 1, 2, 3, 4, 6, 5, 7][s])
 
 
-def cube_front_image_encode(cube: npt.NDArray, s: int) -> npt.NDArray:
+def cube_front_image_encode(cube: xp_ndarray, s: int) -> xp_ndarray:
     """
     Encode image cube - dim 0 is the cube axis
     """
@@ -79,22 +90,23 @@ def cube_front_image_encode(cube: npt.NDArray, s: int) -> npt.NDArray:
     if s == 0:
         return cube
     elif s == 1:
-        return cube[:, ::-1, :]
+        return cube[:, ::-1, :]  # type: ignore
     elif s == 2:
-        return cube[:, :, ::-1]
+        return cube[:, :, ::-1]  # type: ignore
     elif s == 3:
-        return cube[:, ::-1, ::-1]
+        return cube[:, ::-1, ::-1]  # type: ignore
     else:
-        return cube_front_image_encode(np.swapaxes(cube, 1, 2), s - 4)
+        xp = get_array_module(cube)
+        return cube_front_image_encode(xp.swapaxes(cube, 1, 2), s - 4)
 
 
-def cube_front_image_decode(cube: npt.NDArray, s: int) -> npt.NDArray:
+def cube_front_image_decode(cube: xp_ndarray, s: int) -> xp_ndarray:
     if s < 0 or s > 7:
         raise ValueError("symcode s must be 0-7")
     return cube_front_image_encode(cube, [0, 1, 2, 3, 4, 6, 5, 7][s])
 
 
-def cube_back_image_encode(cube: npt.NDArray, s: int) -> npt.NDArray:
+def cube_back_image_encode(cube: xp_ndarray, s: int) -> xp_ndarray:
     """
     Encode image cube - dim 2 is the cube axis
     """
@@ -104,16 +116,17 @@ def cube_back_image_encode(cube: npt.NDArray, s: int) -> npt.NDArray:
     if s == 0:
         return cube
     elif s == 1:
-        return cube[::-1, :, :]
+        return cube[::-1, :, :]  # type: ignore
     elif s == 2:
-        return cube[:, ::-1, :]
+        return cube[:, ::-1, :]  # type: ignore
     elif s == 3:
-        return cube[::-1, ::-1, :]
+        return cube[::-1, ::-1, :]  # type: ignore
     else:
-        return cube_back_image_encode(np.swapaxes(cube, 0, 1), s - 4)
+        xp = get_array_module(cube)
+        return cube_back_image_encode(xp.swapaxes(cube, 0, 1), s - 4)
 
 
-def cube_back_image_decode(cube: npt.NDArray, s: int) -> npt.NDArray:
+def cube_back_image_decode(cube: xp_ndarray, s: int) -> xp_ndarray:
     if s < 0 or s > 7:
         raise ValueError("symcode s must be 0-7")
     return cube_back_image_encode(cube, [0, 1, 2, 3, 4, 6, 5, 7][s])
@@ -170,15 +183,17 @@ class Which3DState:
     FRONT2LAST = 3
 
 
-def cube_roll_forw(cube: np.ndarray) -> np.ndarray:
-    return np.moveaxis(cube, 2, 0)
+def cube_roll_forw(cube: xp_ndarray) -> xp_ndarray:
+    xp = get_array_module(cube)
+    return xp.moveaxis(cube, 2, 0)
 
 
-def cube_roll_back(cube: np.ndarray) -> np.ndarray:
-    return np.moveaxis(cube, 0, 2)
+def cube_roll_back(cube: xp_ndarray) -> xp_ndarray:
+    xp = get_array_module(cube)
+    return xp.moveaxis(cube, 0, 2)
 
 
-def full_cube_encode(cube: np.ndarray, s: int, tri_dim: int) -> np.ndarray:
+def full_cube_encode(cube: xp_ndarray, s: int, tri_dim: int) -> xp_ndarray:
     if tri_dim in [Which3DState.FRONT2FRONT, Which3DState.FRONT2LAST]:
         cube = cube_front_image_encode(cube, s)
     else:
@@ -192,7 +207,7 @@ def full_cube_encode(cube: np.ndarray, s: int, tri_dim: int) -> np.ndarray:
     return cube
 
 
-def full_cube_decode(cube: np.ndarray, s: int, tri_dim: int) -> np.ndarray:
+def full_cube_decode(cube: xp_ndarray, s: int, tri_dim: int) -> xp_ndarray:
     if tri_dim == Which3DState.LAST2FRONT:
         cube = cube_roll_back(cube)
     elif tri_dim == Which3DState.FRONT2LAST:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "docopt",
   "libtmux",
   "numpy",
+  # "cupy", # KEEP OPTIONAL
   "tqdm",
   "astropy",
 ]
@@ -42,6 +43,11 @@ addopts = [
     "--import-mode=importlib",
     "--ignore=mains/*",
 ]
+
+reportMissingImports = true
+reportMissingTypeStubs = false
+pythonVersion = "3.10"
+pythonPlatform = "Linux"
 
 [tool.coverage.run]
 command_line = "-m pytest"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import pytest
 
 import os
 
+# Don't remove.
+# This must be done as early as possible... see in that file.
 from pyMilk.interfacing import glib_loader_fix
 
 # Fetch autouse MILK fixtures from pyMilk

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,11 @@ from pyMilk.interfacing import glib_loader_fix
 
 # Fetch autouse MILK fixtures from pyMilk
 pytest_plugins = [
-        "tests.conftestaux.cacao_loop", "tests.conftestaux.milk",
-        "tests.conftestaux.coverage", "tests.conftestaux.async_shm_fixtures"
+        "tests.conftestaux.cacao_loop",
+        "tests.conftestaux.milk",
+        "tests.conftestaux.coverage",
+        "tests.conftestaux.async_shm_fixtures",
+        "tests.conftestaux.gpu_transfer_monitor",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,8 @@ from pyMilk.interfacing import glib_loader_fix
 
 # Fetch autouse MILK fixtures from pyMilk
 pytest_plugins = [
-        "tests.conftestaux.cacao_loop",
-        "tests.conftestaux.milk",
-        "tests.conftestaux.coverage",
-        "tests.conftestaux.async_shm_fixtures",
+        "tests.conftestaux.cacao_loop", "tests.conftestaux.milk",
+        "tests.conftestaux.coverage", "tests.conftestaux.async_shm_fixtures"
 ]
 
 

--- a/tests/conftest_test.py
+++ b/tests/conftest_test.py
@@ -28,3 +28,55 @@ def test_cwd_to_temp_fixture():
     # last dir made by the fixture...
     # if other fixtures change cwd further, they should also revert and also not be autouse.
     assert cwd.endswith('pytest_dont_use_for_anything0')
+
+
+def _subprocess_function():
+    import numpy as np
+    from pyMilk.interfacing.shm import SHM
+    s = SHM('gpu', ((100, 100), np.float32), location=0)
+    for _ in range(100):
+        s.set_data(np.zeros((100, 100), np.float32))
+    s.destroy()
+
+
+def test_counts_in_subprocess():
+    if not IMAGESTREAMIO_HAVE_CUDA:
+        pytest.skip("No CUDA -- skipping this test")
+
+    import multiprocessing
+    from .conftestaux.gpu_transfer_monitor import count_subprocess_transfers
+
+    # Use 'spawn' so the child gets a clean CUDA context.
+    ctx = multiprocessing.get_context('spawn')
+
+    with count_subprocess_transfers() as (counts, spy):
+        p = ctx.Process(target=spy(_subprocess_function))
+        p.start()
+        p.join()
+        assert p.exitcode == 0, f"subprocess exited with code {p.exitcode}"
+
+    # _subprocess_function: 1 create (H→D init write) + 100 set_data H→D
+    assert counts.dtoh == 0
+    assert counts.htod == 101
+
+
+def test_counts_in_popen():
+    if not IMAGESTREAMIO_HAVE_CUDA:
+        pytest.skip("No CUDA -- skipping this test")
+
+    import subprocess, shlex
+    from .conftestaux.gpu_transfer_monitor import count_popen_transfers
+
+    with count_popen_transfers() as (counts, extra_env):
+        proc = subprocess.Popen(
+                shlex.
+                split('python -c "from pyMilk.interfacing.shm import SHM; import numpy as np; s = SHM(\'gpu\', ((10,20), np.float32),location=0); s.destroy()"'
+                      ), env={
+                              **os.environ,
+                              **extra_env
+                      })
+        proc.wait()
+
+    assert proc.returncode == 0
+    assert counts.dtoh == 0
+    assert counts.htod == 1

--- a/tests/conftest_test.py
+++ b/tests/conftest_test.py
@@ -6,6 +6,9 @@ in
 actually do their job.
 '''
 import os
+import pytest
+
+from pyMilk.interfacing.shm import IMAGESTREAMIO_HAVE_CUDA
 
 
 def test_milk_shm_dir_fixture():

--- a/tests/conftestaux/gpu_transfer_monitor.py
+++ b/tests/conftestaux/gpu_transfer_monitor.py
@@ -48,6 +48,40 @@ import pytest
 # Locate the shared library relative to this file
 # ---------------------------------------------------------------------------
 
+
+def attempt_build_libcupti_spy():
+    import subprocess
+    """
+    Attempts to build the CUPTI spy library from tests/gpu_monitor/Makefile.
+    If the build fails, it will skip GPU transfer monitoring tests but not fail the session.
+    """
+    gpu_monitor_dir = Path(__file__).parent.parent / "gpu_monitor"
+
+    try:
+        # Run make to build libcupti_spy.so
+        subprocess.run(
+                ["make"],
+                cwd=gpu_monitor_dir,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=True,
+        )
+        print(f"Successfully built libcupti_spy.so from {gpu_monitor_dir}")
+    except subprocess.CalledProcessError as e:
+        print(f"Warning: Failed to build libcupti_spy.so from {gpu_monitor_dir}"
+              )
+        print(f"stdout: {e.stdout}")
+        print(f"stderr: {e.stderr}")
+    except FileNotFoundError:
+        print(f"Warning: make command not found or gpu_monitor directory not found at {gpu_monitor_dir}"
+              )
+    except subprocess.TimeoutExpired:
+        print(f"Warning: Building libcupti_spy.so timed out")
+    except Exception as e:
+        print(f"Warning: Unexpected error building libcupti_spy.so: {e}")
+
+
 _LIB_PATH = Path(__file__).parent.parent / "gpu_monitor" / "libcupti_spy.so"
 
 
@@ -56,6 +90,7 @@ class CuptiSpyUnavailable(RuntimeError):
 
 
 def _load_lib() -> ctypes.CDLL:
+    attempt_build_libcupti_spy()
 
     if not _LIB_PATH.exists():
         raise CuptiSpyUnavailable(

--- a/tests/conftestaux/gpu_transfer_monitor.py
+++ b/tests/conftestaux/gpu_transfer_monitor.py
@@ -1,0 +1,269 @@
+"""
+gpu_transfer_monitor.py — CUPTI-based GPU host-transfer monitoring for pytest.
+
+Loads the companion libcupti_spy.so (built from tests/gpu_monitor/Makefile)
+to intercept **all** cudaMemcpy calls in the current process, regardless of
+which library initiated them (CuPy, PyTorch, pyMilk, etc.).
+
+Usage
+-----
+As a context manager in a test:
+
+    from tests.conftestaux.gpu_transfer_monitor import assert_no_gpu_host_transfers
+
+    def test_zero_copy_roundtrip():
+        shm = SHM('my_gpu_stream')
+        with assert_no_gpu_host_transfers():
+            arr = cupy.asarray(shm.IMAGE.view())  # must be zero-copy
+            shm.set_data(arr)
+
+As a pytest fixture (add to conftest.py plugins list and use as parameter):
+
+    def test_zero_copy_roundtrip(no_gpu_host_transfers):
+        ...
+
+Availability guard
+------------------
+If libcupti_spy.so has not been built, attempting to call either the context
+manager or the fixture raises ``CuptiSpyUnavailable`` — tests that import the
+fixture are automatically skipped via ``pytest.importorskip``-style logic.
+Build the library first with::
+
+    make -C tests/gpu_monitor/
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import struct
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Locate the shared library relative to this file
+# ---------------------------------------------------------------------------
+
+_LIB_PATH = Path(__file__).parent.parent / "gpu_monitor" / "libcupti_spy.so"
+
+
+class CuptiSpyUnavailable(RuntimeError):
+    """Raised when libcupti_spy.so has not been built."""
+
+
+def _load_lib() -> ctypes.CDLL:
+
+    if not _LIB_PATH.exists():
+        raise CuptiSpyUnavailable(
+                f"libcupti_spy.so not found at {_LIB_PATH}. "
+                "Run  make -C tests/gpu_monitor/  to build it.")
+
+    lib = ctypes.CDLL(str(_LIB_PATH))
+
+    lib.cupti_spy_start.restype = None
+    lib.cupti_spy_start.argtypes = []
+
+    lib.cupti_spy_stop.restype = None
+    lib.cupti_spy_stop.argtypes = []
+
+    lib.cupti_spy_get_dtoh.restype = ctypes.c_uint64
+    lib.cupti_spy_get_dtoh.argtypes = []
+
+    lib.cupti_spy_get_htod.restype = ctypes.c_uint64
+    lib.cupti_spy_get_htod.argtypes = []
+
+    CUPTI_SPY_LIB = lib
+    return lib
+
+
+CUPTI_SPY_LIB: ctypes.CDLL | None = None
+try:
+    CUPTI_SPY_LIB = _load_lib()
+except CuptiSpyUnavailable as exc:
+    print(repr(exc))
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def assert_no_gpu_host_transfers() -> Generator[None, None, None]:
+    """
+    Context manager that raises AssertionError if any cudaMemcpy
+    DeviceToHost or HostToDevice call occurs inside the block.
+
+    Raises CuptiSpyUnavailable if the native library has not been built.
+    """
+    assert CUPTI_SPY_LIB is not None
+    CUPTI_SPY_LIB.cupti_spy_start()
+    try:
+        yield
+    finally:
+        CUPTI_SPY_LIB.cupti_spy_stop()
+
+    dtoh: int = CUPTI_SPY_LIB.cupti_spy_get_dtoh()
+    htod: int = CUPTI_SPY_LIB.cupti_spy_get_htod()
+
+    assert dtoh == 0 and htod == 0, (
+            f"Unexpected GPU host transfers detected: "
+            f"{dtoh} DeviceToHost,  {htod} HostToDevice")
+
+
+from dataclasses import dataclass
+
+
+@dataclass
+class TransferCounter:
+    htod: int = 0
+    dtoh: int = 0
+
+
+@contextmanager
+def count_gpu_host_transfers() -> Generator[TransferCounter, None, None]:
+    """
+    Context manager that yields a mutable dict ``{'dtoh': N, 'htod': N}``
+    populated with transfer counts after the block exits.
+
+    Example::
+
+        with count_gpu_host_transfers() as counts:
+            do_work()
+        assert counts['dtoh'] == 0
+    """
+    assert CUPTI_SPY_LIB is not None
+    counts = TransferCounter()
+    CUPTI_SPY_LIB.cupti_spy_start()
+    try:
+        yield counts
+    finally:
+        CUPTI_SPY_LIB.cupti_spy_stop()
+        counts.dtoh = int(CUPTI_SPY_LIB.cupti_spy_get_dtoh())
+        counts.htod = int(CUPTI_SPY_LIB.cupti_spy_get_htod())
+
+
+# ---------------------------------------------------------------------------
+# Pytest fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_gpu_host_transfers() -> Generator[None, None, None]:
+    with assert_no_gpu_host_transfers():
+        yield
+
+
+def _subprocess_spy_wrapper(fn, args, kwargs, lib_path: str, out_path: str):
+    """
+    Module-level picklable wrapper.  Runs in the subprocess: loads
+    libcupti_spy.so, arms CUPTI *after* Python/CUDA are fully initialized,
+    calls fn, then writes counters to out_path for the parent to read.
+    """
+    import ctypes
+    lib = ctypes.CDLL(lib_path)
+    lib.cupti_spy_start.restype = None
+    lib.cupti_spy_start.argtypes = []
+    lib.cupti_spy_stop.restype = None
+    lib.cupti_spy_stop.argtypes = []
+    lib.cupti_spy_write_counts.restype = None
+    lib.cupti_spy_write_counts.argtypes = [ctypes.c_char_p]
+
+    lib.cupti_spy_start()
+    try:
+        fn(*args, **kwargs)
+    finally:
+        lib.cupti_spy_stop()
+        lib.cupti_spy_write_counts(out_path.encode())
+
+
+@contextmanager
+def count_subprocess_transfers():
+    """
+    Context manager that counts GPU host-transfers produced by a subprocess.
+
+    Yields a ``(TransferCounter, spy)`` pair.
+    ``spy(fn, *args, **kwargs)`` returns a picklable callable that wraps *fn*
+    with CUPTI monitoring inside the subprocess.  Use with
+    ``multiprocessing.get_context('spawn')`` so the child starts fresh::
+
+        with count_subprocess_transfers() as (counts, spy):
+            ctx = multiprocessing.get_context('spawn')
+            p = ctx.Process(target=spy(my_gpu_function))
+            p.start()
+            p.join()
+        assert counts.htod == 100
+
+    Raises ``CuptiSpyUnavailable`` if the native library has not been built.
+    """
+    if not _LIB_PATH.exists():
+        raise CuptiSpyUnavailable(
+                f"libcupti_spy.so not found at {_LIB_PATH}. "
+                "Run  make -C tests/gpu_monitor/  to build it.")
+
+    counts = TransferCounter()
+    fd, out_path = tempfile.mkstemp(prefix="cupti_spy_", suffix=".bin")
+    os.close(fd)
+    lib_path = str(_LIB_PATH)
+
+    def spy(fn, *args, **kwargs):
+        """Return a picklable wrapper that monitors fn in the subprocess."""
+        import functools
+        return functools.partial(_subprocess_spy_wrapper, fn, args, kwargs,
+                                 lib_path, out_path)
+
+    try:
+        yield counts, spy
+    finally:
+        try:
+            with open(out_path, "rb") as f:
+                data = f.read(16)
+            if len(data) == 16:
+                dtoh, htod = struct.unpack("<QQ", data)
+                counts.dtoh = int(dtoh)
+                counts.htod = int(htod)
+        except FileNotFoundError:
+            pass
+        finally:
+            try:
+                os.unlink(out_path)
+            except FileNotFoundError:
+                pass
+
+
+@contextmanager
+def count_popen_transfers():
+    if not _LIB_PATH.exists():
+        raise CuptiSpyUnavailable(
+                f"libcupti_spy.so not found at {_LIB_PATH}. "
+                "Run  make -C tests/gpu_monitor/  to build it.")
+
+    counts = TransferCounter()
+    fd, out_path = tempfile.mkstemp(prefix="cupti_spy_", suffix=".bin")
+    os.close(fd)
+
+    extra_env = {
+            "CUDA_INJECTION64_PATH": str(_LIB_PATH),
+            "CUPTI_SPY_FILE": out_path,
+    }
+    try:
+        yield counts, extra_env
+    finally:
+        # read file written by FinalizeInjection in the child
+        try:
+            with open(out_path, "rb") as f:
+                data = f.read(16)
+            if len(data) == 16:
+                dtoh, htod = struct.unpack("<QQ", data)
+                counts.dtoh = int(dtoh)
+                counts.htod = int(htod)
+        except FileNotFoundError:
+            pass
+        finally:
+            try:
+                os.unlink(out_path)
+            except FileNotFoundError:
+                pass

--- a/tests/gpu_monitor/Makefile
+++ b/tests/gpu_monitor/Makefile
@@ -1,0 +1,45 @@
+# Makefile — build libcupti_spy.so
+#
+# Usage:
+#   make                     # auto-detect CUDA_ROOT
+#   make CUDA_ROOT=/opt/cuda  # explicit path
+#
+# Typical CUDA Toolkit layout assumed:
+#   $CUDA_ROOT/include/          — cuda_runtime_api.h
+#   $CUDA_ROOT/extras/CUPTI/include/ — cupti.h
+#   $CUDA_ROOT/lib64/            — libcudart.so
+#   $CUDA_ROOT/extras/CUPTI/lib64/  — libcupti.so
+#
+# If your distro splits CUPTI into a separate package (e.g. libcupti-dev
+# on Ubuntu), cupti.h may land in /usr/local/cuda/extras/CUPTI/include or
+# /usr/include.  Adjust CUPTI_INC / CUPTI_LIB below as needed.
+
+CUDA_ROOT  ?= /usr/local/cuda
+CUPTI_ROOT ?= $(CUDA_ROOT)/extras/CUPTI
+
+CC      = gcc
+CFLAGS  = -fPIC -O2 -Wall -Wextra -std=c11
+
+INC     = -I$(CUDA_ROOT)/include \
+          -I$(CUPTI_ROOT)/include
+
+LDFLAGS = -shared \
+          -L$(CUDA_ROOT)/lib64 \
+          -L$(CUPTI_ROOT)/lib64 \
+          -Wl,-rpath,$(CUDA_ROOT)/lib64 \
+          -Wl,-rpath,$(CUPTI_ROOT)/lib64
+
+LIBS    = -lcupti -lcudart
+
+TARGET  = libcupti_spy.so
+
+# ---------------------------------------------------------------------------
+
+$(TARGET): cupti_spy.c
+	$(CC) $(CFLAGS) $(INC) $(LDFLAGS) -o $@ $< $(LIBS)
+	@echo "Built $(TARGET)"
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY: clean

--- a/tests/gpu_monitor/README.md
+++ b/tests/gpu_monitor/README.md
@@ -1,0 +1,14 @@
+# tests/gpu_monitor
+
+Compile the CUPTI spy library before running GPU integration tests:
+
+```sh
+make -C tests/gpu_monitor/
+# Optional: explicit CUDA path
+make -C tests/gpu_monitor/ CUDA_ROOT=/usr/local/cuda
+```
+
+Output: `tests/gpu_monitor/libcupti_spy.so`
+
+Tests that use `no_gpu_host_transfers` or `assert_no_gpu_host_transfers`
+are automatically skipped (not failed) when the library is absent.

--- a/tests/gpu_monitor/cupti_spy.c
+++ b/tests/gpu_monitor/cupti_spy.c
@@ -1,0 +1,288 @@
+/*
+ * cupti_spy.c — CUPTI callback-based GPU host-transfer monitor.
+ *
+ * Intercepts cudaMemcpy / cudaMemcpyAsync (and their per-thread-stream
+ * variants) at the CUDA runtime API level, counting DeviceToHost and
+ * HostToDevice operations.  Works transparently across ALL libraries in the
+ * same process (CuPy, PyTorch, pyMilk, etc.).
+ *
+ * Build:  see accompanying Makefile → libcupti_spy.so
+ * Use:    load from Python via ctypes (see gpu_transfer_monitor.py)
+ */
+
+#define _GNU_SOURCE
+
+#include <cupti.h>
+
+#include <fcntl.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+/* -------------------------------------------------------------------------
+ * Internal state
+ * ---------------------------------------------------------------------- */
+
+static _Atomic uint64_t g_dtoh_count = 0;
+static _Atomic uint64_t g_htod_count = 0;
+
+static CUpti_SubscriberHandle g_subscriber = NULL;
+
+/* -------------------------------------------------------------------------
+ * Parameter structs for the memcpy variants we care about.
+ * These have been stable since CUDA 3.2; kind is always the 4th field.
+ *
+ * We use plain int / void* instead of cudaMemcpyKind / cudaStream_t so that
+ * this file can be compiled with plain gcc (no nvcc required).  The field
+ * layout matches the CUDA ABI exactly.
+ * ---------------------------------------------------------------------- */
+
+typedef struct
+{
+    void *dst;
+    const void *src;
+    size_t count;
+    int kind;   /* cudaMemcpyKind */
+} _sync_params; /* cudaMemcpy, cudaMemcpy_ptds */
+
+typedef struct
+{
+    void *dst;
+    const void *src;
+    size_t count;
+    int kind;     /* cudaMemcpyKind */
+    void *stream; /* cudaStream_t */
+} _async_params;  /* cudaMemcpyAsync, cudaMemcpyAsync_ptsz */
+
+/* -------------------------------------------------------------------------
+ * CUPTI callback
+ * ---------------------------------------------------------------------- */
+
+static void CUPTIAPI _spy_callback(
+    void *userdata,
+    CUpti_CallbackDomain domain,
+    CUpti_CallbackId cbid,
+    const CUpti_CallbackData *info)
+{
+
+    (void)userdata;
+    (void)domain;
+    (void)cbid;
+
+    /* Only inspect the call on entry (not on exit) */
+    if (info->callbackSite != CUPTI_API_ENTER)
+        return;
+
+    const char *fn = info->functionName;
+    if (!fn)
+        return;
+
+    int kind;
+
+    if (strcmp(fn, "cudaMemcpy") == 0 ||
+        strcmp(fn, "cudaMemcpy_ptds") == 0)
+    {
+        kind = ((_sync_params *)info->functionParams)->kind;
+    }
+    else if (strcmp(fn, "cudaMemcpyAsync") == 0 ||
+             strcmp(fn, "cudaMemcpyAsync_ptsz") == 0)
+    {
+        kind = ((_async_params *)info->functionParams)->kind;
+    }
+    else
+    {
+        /*
+         * cudaMemcpy2D, cudaMemcpyToSymbol, cudaMemcpyFromSymbol, etc. are
+         * not counted here.  Add cases above if your workload uses them.
+         *
+         * For driver-API copies (cuMemcpyDtoH_v2 / cuMemcpyHtoD_v2) enable
+         * CUPTI_CB_DOMAIN_DRIVER_API in cupti_spy_start() and handle them
+         * here analogously.
+         */
+        return;
+    }
+
+    /* cudaMemcpyHostToDevice=1, cudaMemcpyDeviceToHost=2 — stable since CUDA 1.0 */
+    if (kind == 2)
+        atomic_fetch_add(&g_dtoh_count, 1);
+    else if (kind == 1)
+        atomic_fetch_add(&g_htod_count, 1);
+    /* DeviceToDevice / Unified stays on GPU — not counted */
+}
+
+/* -------------------------------------------------------------------------
+ * Public API (called from Python via ctypes)
+ * ---------------------------------------------------------------------- */
+
+/**
+ * cupti_spy_start — reset counters and begin intercepting memcpy calls.
+ * Safe to call multiple times; each call resets the counters.
+ */
+void cupti_spy_start(void)
+{
+    atomic_store(&g_dtoh_count, 0);
+    atomic_store(&g_htod_count, 0);
+
+    if (g_subscriber != NULL)
+        cuptiUnsubscribe(g_subscriber);
+
+    CUptiResult r = cuptiSubscribe(&g_subscriber,
+                                   (CUpti_CallbackFunc)_spy_callback,
+                                   NULL);
+    if (r != CUPTI_SUCCESS)
+    {
+        fprintf(stderr, "cupti_spy: cuptiSubscribe failed (%d)\n", (int)r);
+        g_subscriber = NULL;
+        return;
+    }
+
+    r = cuptiEnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_RUNTIME_API);
+    if (r != CUPTI_SUCCESS)
+    {
+        fprintf(stderr, "cupti_spy: cuptiEnableDomain failed (%d)\n", (int)r);
+        g_subscriber = NULL;
+        return;
+    }
+}
+
+/**
+ * cupti_spy_stop — disable interception.  Counters are still readable
+ * after this call.
+ */
+void cupti_spy_stop(void)
+{
+    if (g_subscriber != NULL)
+    {
+        cuptiEnableDomain(0, g_subscriber, CUPTI_CB_DOMAIN_RUNTIME_API);
+        cuptiUnsubscribe(g_subscriber);
+        g_subscriber = NULL;
+    }
+}
+
+/** Return number of DeviceToHost transfers recorded since last start. */
+uint64_t cupti_spy_get_dtoh(void)
+{
+    return (uint64_t)atomic_load(&g_dtoh_count);
+}
+
+/** Return number of HostToDevice transfers recorded since last start. */
+uint64_t cupti_spy_get_htod(void)
+{
+    return (uint64_t)atomic_load(&g_htod_count);
+}
+
+/**
+ * cupti_spy_write_counts — write [dtoh, htod] as two little-endian uint64_t
+ * to the given file path.  Called explicitly from Python wrappers in the
+ * subprocess after cupti_spy_stop().
+ */
+void cupti_spy_write_counts(const char *path)
+{
+    if (!path || *path == '\0')
+        return;
+
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0)
+    {
+        perror("cupti_spy: could not open path");
+        return;
+    }
+
+    uint64_t counts[2] = {
+        atomic_load(&g_dtoh_count),
+        atomic_load(&g_htod_count),
+    };
+
+    ssize_t written = write(fd, counts, sizeof(counts));
+    if (written != (ssize_t)sizeof(counts))
+        fprintf(stderr, "cupti_spy: short write to %s\n", path);
+
+    close(fd);
+}
+
+/* -------------------------------------------------------------------------
+ * Injection entry points (CUDA_INJECTION64_PATH support)
+ *
+ * When CUDA_INJECTION64_PATH=/path/to/libcupti_spy.so is set in the
+ * environment, the CUDA runtime calls InitializeInjection() during cuInit()
+ * and FinalizeInjection() at shutdown — before any application code runs or
+ * after all CUDA work is done, respectively.
+ *
+ * Counts are persisted to the file named by CUPTI_SPY_FILE (if set) as
+ * two little-endian uint64_t values: [dtoh, htod].  The parent process reads
+ * them after the child exits.
+ * ---------------------------------------------------------------------- */
+
+static void _write_counts_to_file(void)
+{
+    const char *path = getenv("CUPTI_SPY_FILE");
+    if (!path)
+        return;
+
+    cupti_spy_write_counts(path);
+}
+
+/*
+ * Single dispatcher used by the injection subscriber.
+ * During cuInit it receives CUPTI_CB_DOMAIN_RESOURCE events; once
+ * CU_INIT_FINISHED fires the runtime domain is armed and subsequent calls
+ * come in as CUPTI_CB_DOMAIN_RUNTIME_API events which are forwarded to the
+ * counting logic in _spy_callback.
+ */
+static void CUPTIAPI _injection_dispatch_callback(
+        void                     *userdata,
+        CUpti_CallbackDomain      domain,
+        CUpti_CallbackId          cbid,
+        const CUpti_CallbackData *info)
+{
+    if (domain == CUPTI_CB_DOMAIN_RESOURCE) {
+        if (cbid == CUPTI_CBID_RESOURCE_CU_INIT_FINISHED) {
+            /* CUPTI is now fully ready — arm the runtime memcpy callbacks. */
+            cuptiEnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_RUNTIME_API);
+            /* Resource domain no longer needed. */
+            cuptiEnableDomain(0, g_subscriber, CUPTI_CB_DOMAIN_RESOURCE);
+        }
+        return;
+    }
+
+    /* Otherwise delegate to the normal counting callback. */
+    _spy_callback(userdata, domain, cbid, info);
+}
+
+static int finalized = 0;
+
+void FinalizeInjection(void)
+{
+    if (!finalized) {
+        finalized = 1;
+        cupti_spy_stop();
+        _write_counts_to_file();
+    }
+}
+
+int InitializeInjection(void)
+{
+    atomic_store(&g_dtoh_count, 0);
+    atomic_store(&g_htod_count, 0);
+
+    if (g_subscriber != NULL)
+        cuptiUnsubscribe(g_subscriber);
+
+    CUptiResult r = cuptiSubscribe(&g_subscriber,
+                                   (CUpti_CallbackFunc)_injection_dispatch_callback,
+                                   NULL);
+    if (r != CUPTI_SUCCESS) {
+        fprintf(stderr, "cupti_spy: injection cuptiSubscribe failed (%d)\n", (int)r);
+        g_subscriber = NULL;
+        return 0;
+    }
+
+    /* Enable the resource domain to receive CU_INIT_FINISHED.
+     * The runtime domain will be enabled from that callback. */
+    cuptiEnableDomain(1, g_subscriber, CUPTI_CB_DOMAIN_RESOURCE);
+
+    atexit(FinalizeInjection);
+    return 1;
+}

--- a/tests/interfacing/gpu_shm_test.py
+++ b/tests/interfacing/gpu_shm_test.py
@@ -151,12 +151,18 @@ def test_gpu_shm_from_np_cp():
     s_gpu = SHM('x', x_cp, location=0)
     assert type(s_gpu.get_data(copy=False)) == cp.ndarray
     assert np.all(s_gpu.get_data(copy=True) == -x_np)
-    assert np.all(s_gpu.get_data(copy=False) == x_cp)
+    # cp.all is broken when running off cupy-cudaVERx + system CUDA
+    # assert cp.all(s_gpu.get_data(copy=False) == +x_cp)
+    gpu_tmp = s_gpu.get_data(copy=False) - x_cp
+    assert np.all(gpu_tmp.get() == 0.0)
     s_gpu.destroy()
 
     s_gpu = SHM('x', x_np, location=0)
     assert np.all(s_gpu.get_data(copy=True) == x_np)
-    assert np.all(s_gpu.get_data(copy=False) == -x_cp)
+    # cp.all is broken when running off cupy-cudaVERx + system CUDA
+    # assert cp.all(s_gpu.get_data(copy=False) == -x_cp)
+    gpu_tmp = s_gpu.get_data(copy=False) + x_cp
+    assert np.all(gpu_tmp.get() == 0.0)
 
     s_gpu.destroy()
 

--- a/tests/interfacing/gpu_shm_test.py
+++ b/tests/interfacing/gpu_shm_test.py
@@ -110,6 +110,27 @@ def test_external_process_serves_shm_and_make_zombie(serve_external_shm: SHM,
     assert np.all(overwrite.get_data() == -1.0)
 
 
+def test_no_gpu_memcpy():
+    from ..conftestaux.gpu_transfer_monitor import assert_no_gpu_host_transfers
+    with assert_no_gpu_host_transfers():
+        pass
+
+
+def test_yes_gpu_memcpy():
+    s = SHM('yolo', ((5, 10), np.int64), location=0)
+    from ..conftestaux.gpu_transfer_monitor import count_gpu_host_transfers
+    with count_gpu_host_transfers() as counts:
+        s.get_data()
+
+    assert counts.dtoh > 0
+    assert counts.htod == 0
+
+    with count_gpu_host_transfers() as counts:
+        s.set_data((np.random.randn(5, 10) * 100).astype(np.int64))
+    assert counts.dtoh == 0
+    assert counts.htod > 0
+
+
 def test_cp_array_to_cpu_shm():
     x_np = np.random.randn(123, 45).astype(np.float32)
     x_cp = cp.array(-x_np)
@@ -138,3 +159,51 @@ def test_gpu_shm_from_np_cp():
     assert np.all(s_gpu.get_data(copy=False) == -x_cp)
 
     s_gpu.destroy()
+
+
+def test_gpu_countcopy():
+    initializer_data = np.random.randn(123, 45, 67).astype(np.float32)
+    initializer_data.flat[0] = 0  # counter
+    s = SHM('test', initializer_data, location=0)
+    assert s.location == 0
+
+    from ..conftestaux.gpu_transfer_monitor import count_gpu_host_transfers
+
+    with count_gpu_host_transfers() as count:
+        t1 = time.time()
+        for _ in range(1_000):
+            cpu_data = s.get_data(copy=True)
+            cpu_data.flat[0] += 1
+            s.set_data(cpu_data)
+        print(f'Time in loop for test_gpu_zerocopy: {time.time() - t1:.6f} s')
+    assert count.dtoh == 1000
+    assert count.htod == 1000
+    assert s.get_data().flat[0] == 1000
+
+    s.destroy()
+
+
+def test_gpu_zerocopy():
+    # Big arrays:   PCI memcpy dominates, zerocopy is faster
+    # Small arrays: Driver calls to GPU dominate, zerocopy (on-device-copy but no PCI transfer) is slower.
+    initializer_data = np.random.randn(123, 45, 67).astype(np.float32)
+    initializer_data.flat[0] = 0  # counter
+    s = SHM('test', initializer_data, location=0)
+    assert s.location == 0
+
+    from ..conftestaux.gpu_transfer_monitor import count_gpu_host_transfers
+
+    s.set_data(initializer_data)
+    with count_gpu_host_transfers() as count:
+        t1 = time.time()
+        for _ in range(1_000):
+            gpu_data = s.get_data(copy=False)
+            gpu_data.flat[
+                    0] += 1.0  # This kernel launch costs time, but not what we're testing here.
+            s.set_data(gpu_data)
+        print(f'Time in loop for test_gpu_zerocopy: {time.time() - t1:.6f} s')
+    assert count.dtoh == 0
+    assert count.htod == 0
+    assert s.get_data().flat[0] == 1000
+
+    s.destroy()

--- a/tests/interfacing/gpu_shm_test.py
+++ b/tests/interfacing/gpu_shm_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 import os
+import time
 
 import numpy as np
 
@@ -8,6 +9,12 @@ from pyMilk.interfacing.shm import SHM, check_SHM_name
 from pyMilk import errors
 
 from ..conftestaux.async_shm_fixtures import serve_external_shm
+
+from pyMilk.interfacing.shm import IMAGESTREAMIO_HAVE_CUDA
+if not IMAGESTREAMIO_HAVE_CUDA:
+    pytest.skip("Skipping GPU tests.", allow_module_level=True)
+
+import cupy as cp
 
 
 @pytest.mark.parametrize('data', [
@@ -73,3 +80,61 @@ def test_double_open_with_data_sanity():
 def test_external_process_serves_shm(serve_external_shm: SHM):
     # Nothing to test, the fixture already opened the local SHM and will close it.
     assert np.all(serve_external_shm.get_data() == 0.0)
+
+
+@pytest.mark.parametrize('serve_external_shm', [('gpu_test',
+                                                 (100, 200), np.float64, 0)],
+                         indirect=True)
+@pytest.mark.parametrize('overwrite_location', [-1, 0])
+def test_external_process_serves_shm_and_make_zombie(serve_external_shm: SHM,
+                                                     overwrite_location: int):
+    # Nothing to test, the fixture already opened the local SHM and will close it.
+    assert np.all(serve_external_shm.get_data() == 0.0)
+    z_data = serve_external_shm.get_data()
+
+    new_handle = SHM(serve_external_shm.FNAME)
+
+    overwrite = SHM(serve_external_shm.FNAME, z_data - 1,
+                    location=overwrite_location)
+
+    # We purposefully _disable_ autorelink_if_need
+    # Otherwise we'd just automatically relink to overwritecpu.
+    # But here we're testing that the zombie is staying alive
+
+    assert np.all(serve_external_shm.get_data(autorelink_if_need=False) == 0.0)
+    assert np.all(overwrite.get_data() == -1.0)
+
+    new_handle.set_data(z_data + 1, autorelink_if_need=False)
+    assert np.all(
+            serve_external_shm.get_data(autorelink_if_need=False) == +1.0)
+    assert np.all(overwrite.get_data() == -1.0)
+
+
+def test_cp_array_to_cpu_shm():
+    x_np = np.random.randn(123, 45).astype(np.float32)
+    x_cp = cp.array(-x_np)
+
+    s_cpu = SHM('x', x_np)
+
+    s_cpu.set_data(x_cp)
+
+    assert np.all(s_cpu.get_data() == -x_np)
+
+    s_cpu.destroy()
+
+
+def test_gpu_shm_from_np_cp():
+    x_np = np.random.randn(123, 45).astype(np.float32)
+    x_cp = cp.array(-x_np)
+
+    s_gpu = SHM('x', x_cp, location=0)
+    assert type(s_gpu.get_data(copy=False)) == cp.ndarray
+    assert np.all(s_gpu.get_data(copy=True) == -x_np)
+    assert np.all(s_gpu.get_data(copy=False) == x_cp)
+    s_gpu.destroy()
+
+    s_gpu = SHM('x', x_np, location=0)
+    assert np.all(s_gpu.get_data(copy=True) == x_np)
+    assert np.all(s_gpu.get_data(copy=False) == -x_cp)
+
+    s_gpu.destroy()

--- a/tests/interfacing/non_shared_shm_test.py
+++ b/tests/interfacing/non_shared_shm_test.py
@@ -28,7 +28,13 @@ def test_data_conservation(shape: tuple[int, ...], location: int):
             shm_write.destroy()
 
 
-def test_shared_nonshared_overlap(location1: int = -1, location2: int = -1):
+@pytest.mark.parametrize('location1', [-1, 0])
+@pytest.mark.parametrize('location2', [-1, 0])
+def test_shared_nonshared_overlap(location1: int, location2: int):
+    from pyMilk.ImageStreamIOWrap import IMAGESTREAMIO_HAVE_CUDA
+    if ((location1 >= 0 or location2 >= 0) and not IMAGESTREAMIO_HAVE_CUDA):
+        pytest.skip("No CUDA -- skipping this test")
+
     data_shared: np.ndarray = np.random.randn(10, 20).astype(np.float32)
     data_private: np.ndarray = np.random.randn(10, 20).astype(np.float32)
     shm_shared_1 = SHM('shared_test', data_shared,


### PR DESCRIPTION
Reimplement GPU SHM support with cupy.

Allows zerocopy GPU SHM access with cupy array views.
Goes with update in nanobind branch of ImageStreamIO

Corresponding test suite.
- Validate SHM features
- Auxiliary test util to measure D2H and H2D transfers
- nox session, detect if cuda was detected during milkengine/ImagestreamIO compilation.